### PR TITLE
Instruct users to run export CODK_DIR=$(pwd)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /out/
 .DS_Store
-/firmware/
+/x86/
 /x86-samples/
-/software/
+/arc/
 /flashpack/

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ cd CODK-M
 make clone
 sudo make install-dep
 make setup
+export CODK_DIR=$(pwd)
 source ../zephyr/zephyr-env.sh
 ```
 


### PR DESCRIPTION
Example projects compile well from the top level dir, but fails to compile
from within the project directory, because CODK_DIR isn't defined.
