### PR TITLE
Add top-level convert-sketch target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ OUT_ARC_DIR := $(OUT_DIR)/arc
 export CODK_DIR ?= $(TOP_DIR)
 X86_PROJ_DIR ?= $(CODK_X86_DIR)
 ARC_PROJ_DIR ?= $(CODK_ARC_DIR)/examples/ASCIITable/
+SKETCH       ?= $(ARC_PROJ_DIR)/$(shell basename $(ARC_PROJ_DIR)).ino
+SKETCH_DIR   := $(dir $(SKETCH))
 
 help:
 
@@ -70,6 +72,9 @@ $(OUT_DIR):
 
 compile-arc:
 	CODK_DIR=$(CODK_DIR) $(MAKE) -C $(ARC_PROJ_DIR) compile
+
+convert-sketch:
+	CODK_DIR=$(CODK_DIR) $(MAKE) -C $(SKETCH_DIR) convert-sketch SKETCH=$(notdir $(SKETCH))
 
 upload: upload-dfu
 


### PR DESCRIPTION
Allow convert-sketch target to be called from top-level. If no SKETCH is defined, assume a sketch is in the default app folder with the same name as the folder (e.g., ASCIITable)
