### PR TITLE
Add 'project' Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ CODK_X86SAMPLES_TAG ?= master
 CODK_FLASHPACK_URL := https://github.com/01org/CODK-Z-Flashpack.git
 CODK_FLASHPACK_DIR := $(TOP_DIR)/flashpack
 CODK_FLASHPACK_TAG := master
+PROJ_TEMPLATE_DIR := $(TOP_DIR)/template
 BLE_IMAGE  := $(CODK_FLASHPACK_DIR)/images/firmware/ble_core/imagev3.bin
 ZEPHYR_DIR := $(TOP_DIR)/../zephyr
 ZEPHYR_DIR_REL = $(shell $(CODK_FLASHPACK_DIR)/relpath "$(TOP_DIR)" "$(ZEPHYR_DIR)")
@@ -19,6 +20,7 @@ ZEPHYR_SDK_VER := 0.8.1
 OUT_DIR := $(TOP_DIR)/out
 OUT_X86_DIR := $(OUT_DIR)/x86
 OUT_ARC_DIR := $(OUT_DIR)/arc
+PROJNAME := user_project
 
 export CODK_DIR ?= $(TOP_DIR)
 X86_PROJ_DIR ?= $(CODK_X86_DIR)
@@ -137,3 +139,7 @@ debug-x86:
 
 debug-arc:
 	$(CODK_ARC_DIR)/arc32/bin/arc-elf32-gdb $(ARC_PROJ_DIR)/arc-debug.elf
+
+project:
+	@if [ -d $(PROJNAME) ]; then echo "$(PROJNAME) already exists."; exit 1; fi
+	@cp -r $(PROJ_TEMPLATE_DIR) $(PROJNAME)

--- a/template/arc/Makefile
+++ b/template/arc/Makefile
@@ -1,0 +1,17 @@
+ifeq ("$(strip $(CODK_DIR))", "")
+  $(error Please set the CODK_DIR variable.)
+endif
+
+ARDUINOSW_DIR ?= $(CODK_DIR)/arc
+
+current_dir = $(shell pwd)
+
+VERBOSE  = true
+
+LIBDIRS  =  
+
+include $(ARDUINOSW_DIR)/Makefile.inc
+
+all: compile
+
+.DEFAULT_GOAL := all

--- a/template/x86/Makefile
+++ b/template/x86/Makefile
@@ -1,0 +1,6 @@
+MDEF_FILE = prj.mdef
+BOARD ?= arduino_101_factory
+KERNEL_TYPE ?= micro
+CONF_FILE = prj.conf
+
+include ${ZEPHYR_BASE}/Makefile.inc

--- a/template/x86/prj.conf
+++ b/template/x86/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_ARC_INIT=y

--- a/template/x86/prj.mdef
+++ b/template/x86/prj.mdef
@@ -1,0 +1,6 @@
+% Application       : C++ demo
+
+% TASK NAME  PRIO ENTRY STACK GROUPS
+% ==================================
+  TASK MAIN    7  main  2048  [EXE]
+

--- a/template/x86/src/Makefile
+++ b/template/x86/src/Makefile
@@ -1,0 +1,1 @@
+obj-y += main.o

--- a/template/x86/src/main.c
+++ b/template/x86/src/main.c
@@ -1,0 +1,6 @@
+#include <zephyr.h>
+
+void main (void)
+{
+
+}


### PR DESCRIPTION
This target creates a new empty project. Reqested by multiple bootcamp
participants.

@calvinatintel @bbaltz505 @SidLeung @bigdinotech Please review.

Note that we will do usability testing of this today at bootcamp; if it works well then I'll add it to other trees. Please don't merge until it is explicitly requested
