### PR TITLE
Add 'project' target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,12 @@ CODK_X86_TAG ?= master
 CODK_X86SAMPLES_URL := https://github.com/01org/CODK-M-X86-Samples.git
 CODK_X86SAMPLES_DIR := $(TOP_DIR)/x86-samples
 CODK_X86SAMPLES_TAG ?= master
+GEN_USER_ENV := $(TOP_DIR)/gen_user_env.sh
+BLANK_ARC := $(CODK_ARC_DIR)/examples/BareMinimum
+BLANK_X86 := $(CODK_X86SAMPLES_DIR)/Blank
+X86SAMPLES_SERVICES_DIR := $(CODK_X86SAMPLES_DIR)/common/arduino101_services
+X86SAMPLES_ARDUINO_DIR := $(CODK_X86SAMPLES_DIR)/common/arduino
+PROJ_DIR := my_project
 CODK_FLASHPACK_URL := https://github.com/01org/CODK-Z-Flashpack.git
 CODK_FLASHPACK_DIR := $(TOP_DIR)/flashpack
 CODK_FLASHPACK_TAG := master
@@ -68,6 +74,7 @@ $(CODK_X86_DIR):
 
 $(CODK_X86SAMPLES_DIR):
 	git clone -b $(CODK_X86SAMPLES_TAG) $(CODK_X86SAMPLES_URL) $(CODK_X86SAMPLES_DIR)
+	cd $(CODK_X86SAMPLES_DIR) && ./create_symlinks.sh
 
 $(CODK_FLASHPACK_DIR):
 	git clone -b $(CODK_FLASHPACK_TAG) $(CODK_FLASHPACK_URL) $(CODK_FLASHPACK_DIR)
@@ -82,6 +89,23 @@ x86-setup:
 arc-setup:
 	@echo "Setting up ARC Firmware"
 	@$(MAKE) -C $(CODK_ARC_DIR) setup CORELIBS_URL=https://github.com/01org/corelibs-arduino101/archive/codk-m.zip
+
+project:
+	@if [ -d $(PROJ_DIR) ]; then echo "$(PROJ_DIR) already exists."; exit 1; fi
+	@mkdir $(CODK_DIR)/$(PROJ_DIR)
+	@cp -r $(BLANK_ARC) $(CODK_DIR)/$(PROJ_DIR)/arc
+	@cp -r $(BLANK_X86) $(CODK_DIR)/$(PROJ_DIR)/x86
+	@$(GEN_USER_ENV) $(CODK_DIR) $(CODK_DIR)/$(PROJ_DIR)
+	@echo
+	@echo "New project created in '$(PROJ_DIR)'"
+	@echo "To work in '$(PROJ_DIR)', exit your current shell session and start"
+	@echo "a new one. Then source your project's env.sh script;"
+	@echo
+	@echo "    $ source $(PROJ_DIR)/env.sh"
+	@echo
+	@echo "Now, you are ready to write code in $(PROJ_DIR)/arc and"
+	@echo "$(PROJ_DIR)/x86"
+	@echo
 
 compile: compile-x86 compile-arc
 

--- a/gen_user_env.sh
+++ b/gen_user_env.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Generates the source-able environment for a newly created
+# CODK project, by combining new values for ARC/X86_PROJ_DIR
+# with the contents of zephyr-env.sh
+
+if [ $# != 2 ]
+then
+    echo "Usage: $0 <CODK_DIR> <PROJ_DIR>"
+    exit 1
+fi
+
+outfile="$2"/env.sh
+
+cat << EOT >> "$outfile"
+if [[ \$_ == \$0 ]]
+then
+        echo "Source this script (don't execute it)"
+        exit 1
+fi
+
+source $1/../zephyr/zephyr-env.sh
+export CODK_DIR=$1
+export ARC_PROJ_DIR=$2/arc
+export X86_PROJ_DIR=$2/x86
+EOT


### PR DESCRIPTION
This target creates a new directory for a project, copies in blank
examples for both ARC & x86, and creates an env.sh script containing
the contents of zephyr-env.sh and new values for ARC/X86_PROJ_DIR.

@calvinatintel @bigdinotech please review.
Note that this depends on https://github.com/01org/CODK-M-X86-Samples/pull/22 and https://github.com/01org/CODK-A-ARC/pull/19

To test, set up CODK-M from scratch like this;
(a little extra effort is required since it's unmerged. Also, note that these steps will not work until https://github.com/01org/CODK-M-X86-Samples/pull/22 is merged)

`git clone https://github.com/01org/CODK-M`
`cd CODK-M`
`git fetch origin pull/27/head:new`
`git checkout new`
`make clone`
`sudo make install-dep`
`make setup`

**Instructions for using the 'project' target:**
1. After installing CODK-M, exit your current shell session and start a new one.
2. Go back to CODK-M
   
   `cd CODK-M`
3. Run `make project`, specifying the desired name of your project directory
   
   `make project PROJ_DIR=my_project`
4. Source the generated `$PROJ_DIR/env.sh`
   
   `source my_project/env.sh`

This sets CODK_DIR, ARC_PROJ_DIR, X86_PROJ_DIR and sources the zephyr environment at   $CODK_DIR/../zephyr/zephyr-env.sh, so you don't need to do these things now when working in `my_project`; just source `env.sh`
1. Now you're ready to compile code in `my_project/arc` and `my_project/x86`.
